### PR TITLE
Basic docs

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -25,4 +25,97 @@
 Usage
 =====
 
-.. automodule:: pywebpack
+A simple example
+----------------
+
+Let's take a simple ``package.json``::
+
+    {
+      "private": true,
+      "name": "example",
+      "version": "0.0.1",
+      "author": "myself",
+      "license": "WTFPL",
+      "description": "example",
+      "dependencies": {
+        "jquery": "^3.2.1"
+      }
+    }
+
+Let's add to it a run script that executes webpack::
+
+    "scripts": {
+      "build": "webpack --config webpack.config.js"
+    }
+
+And the corresponding ``webpack.config.js``::
+
+    var path = require('path');
+
+    module.exports = {
+      context: path.resolve(__dirname, 'src'),
+      entry: './index.js',
+      output: {
+        filename: '[name].js',
+        path: path.resolve(__dirname, 'dist')
+      }
+    };
+
+We can easily wrap our project in a :class:`~pywebpack.project.WebpackProject` object::
+
+    from pywebpack.project import WebpackProject
+    project = WebpackProject('.')
+
+This will allow us to install the dependencies::
+
+    project.install()
+
+And invoke webpack to build the assets::
+
+    project.build()
+
+Alternative, :meth:`~pywebpack.project.WebpackProject.buildall` can be used to execute both tasks at once.
+
+
+Using a manifest
+----------------
+
+Manifests help you deal with long-term caching, by providing a mapping between the name of a resource and its "hashed"
+version::
+
+    {
+      "main.js": "main.75244bb780acd727ebd3.js"
+    }
+
+This package supports manifest files that are compatible with `webpack-manifest-plugin`_, `webpack-yam-plugin`_ and
+`webpack-bundle-tracker`_.
+
+You will normally want webpack to add a hash of a file's contents to its name::
+
+    output: {
+      filename: '[name].[chunkhash].js',
+      path: path.resolve(__dirname, 'dist')
+    }
+
+And then have it invoke your favorite manifest plugin::
+
+    plugins: [
+      new ManifestPlugin({
+        fileName: 'manifest.json'
+      })
+    ]
+
+:class:`~pywebpack.manifests.ManifestLoader` should be able to load a manifest in any of those formats::
+
+    manifest = ManifestLoader.load('/path/to/dist/manifest.json')
+
+The manifest entries can be retrieved as object attributes or items::
+
+    manifest.myresource
+    manifest['myresource']
+    manifest['main.js']
+
+
+.. _webpack-manifest-plugin: https://www.npmjs.com/package/webpack-manifest-plugin
+.. _webpack-yam-plugin: https://www.npmjs.com/package/webpack-yam-plugin
+.. _webpack-bundle-tracker: https://www.npmjs.com/package/webpack-bundle-tracker

--- a/pywebpack/manifests.py
+++ b/pywebpack/manifests.py
@@ -83,6 +83,10 @@ class Manifest(object):
         except KeyError:
             raise AttributeError('Attribute {} does not exists.'.format(name))
 
+    def __iter__(self):
+        """Iterate over entries in the manifest."""
+        return iter(self._entries.viewvalues())
+
 
 class ManifestEntry(object):
     """Represents a manifest entry."""
@@ -107,6 +111,11 @@ class ManifestEntry(object):
                 raise UnsupportedExtensionError(p)
             out.append(tpl.format(p))
         return ''.join(out)
+
+    def __iter__(self):
+        """Iterate over files in the manifest entry."""
+        for path in self._paths:
+            yield path
 
     def __str__(self):
         """Render entry."""

--- a/pywebpack/project.py
+++ b/pywebpack/project.py
@@ -70,7 +70,7 @@ class WebpackProject(object):
 
     def run(self, script_name, *args):
         """Run an NPM script."""
-        scripts = self.npmpkg.package_json.get('scripts').keys()
+        scripts = self.npmpkg.package_json.get('scripts', {}).keys()
         if script_name not in scripts:
             raise RuntimeError('Invalid NPM script.')
         return self.npmpkg.run_script(script_name, *args)

--- a/pywebpack/project.py
+++ b/pywebpack/project.py
@@ -61,7 +61,7 @@ class WebpackProject(object):
     @property
     @cached
     def npmpkg(self):
-        """API to NPM package."""
+        """Get API to NPM package."""
         return NPMPackage(self.path)
 
     def install(self, *args):
@@ -104,7 +104,7 @@ class WebpackTemplateProject(WebpackProject):
 
     @property
     def config(self):
-        """Configuration dictionary."""
+        """Get configuration dictionary."""
         if self._config is None:
             return None
         config = self._config() if callable(self._config) else self._config

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -76,7 +76,7 @@ def bundledir(sourcedir):
 
 @pytest.yield_fixture()
 def destdir(tmpdir):
-    """Example output directory."""
+    """Get example output directory."""
     dst = join(tmpdir, 'simple')
     makedirs(dst)
     yield dst

--- a/tests/test_pywebpack.py
+++ b/tests/test_pywebpack.py
@@ -102,7 +102,7 @@ def test_templateproject_create_config(templatedir, destdir):
     assert json_from_file(project.config_path) == expected_config
 
 
-def test_tempateproject_buildall(templatedir, destdir):
+def test_templateproject_buildall(templatedir, destdir):
     """Test build all."""
     project = WebpackTemplateProject(
         destdir,


### PR DESCRIPTION
Plus a few improvements:

 * Fix exception thrown when `package.json` has no `scripts` section;
 * Fixes in imperative mood of some docstrings;
 * Some useful iterators to navigate the assets of a manifest;