### PR TITLE
Fix problem with package.json not being updated

### DIFF
--- a/pywebpack/helpers.py
+++ b/pywebpack/helpers.py
@@ -34,5 +34,11 @@ def cached(f):
 
 def merge_deps(deps, bundles_deps):
     """Merge NPM dependencies."""
-    deps.update(bundles_deps)
+    keys = ['dependencies', 'devDependencies', 'peerDependencies']
+    for k in keys:
+        if k not in deps:
+            deps[k] = {}
+
+        if k in bundles_deps:
+            deps[k].update(bundles_deps[k])
     return deps

--- a/pywebpack/project.py
+++ b/pywebpack/project.py
@@ -103,9 +103,10 @@ class WebpackTemplateProject(WebpackProject):
         """Storage class property."""
         return self._storage_cls
 
-    def create(self):
+    def create(self, force=None):
         """Create webpack project from a template."""
-        self.storage_cls(self._project_template, self.project_path).run()
+        self.storage_cls(self._project_template, self.project_path).run(
+            force=force)
 
         # Write config if not empty
         config = self.config
@@ -185,16 +186,17 @@ class WebpackBundleProject(WebpackTemplateProject):
         """Merge bundle dependencies into ``package.json``."""
         return merge_deps(self.npmpkg.package_json, self.dependencies)
 
-    def collect(self):
+    def collect(self, force=None):
         """Collect asset files from bundles."""
         for b in self.bundles:
-            self.storage_cls(b.path, self.project_path).run()
+            self.storage_cls(b.path, self.project_path).run(force=force)
 
-    def create(self):
+    def create(self, force={'package.json'}):
         """Create webpack project from a template."""
-        super(WebpackBundleProject, self).create()
+        # Force package.json to be overwritten always.
+        super(WebpackBundleProject, self).create(force=force)
         # Collect all asset files from the bundles.
-        self.collect()
+        self.collect(force=force)
         # Generate new package json (reads the package.json and merges in
         # npm dependencies; must be done before opening the file for writing)
         package_json = self.package_json

--- a/pywebpack/storage.py
+++ b/pywebpack/storage.py
@@ -36,16 +36,17 @@ class FileStorage(object):
         """Iterate files from a directory."""
         return iter_files(self.srcdir)
 
-    def _copyfile(self, src, dst):
+    def _copyfile(self, src, dst, force=False):
         """Copy file from source to destination."""
         if exists(dst):
-            if getmtime(dst) >= getmtime(src):
+            if getmtime(dst) >= getmtime(src) and not force:
                 return
             remove(dst)
         copy(src, dst)
 
-    def run(self):
+    def run(self, force=None):
         """Copy files from source to destination."""
+        force = force or {}
         for fsrc, relpath in self:
             fdst = join(self.dstdir, relpath)
             fdstdir = dirname(fdst)
@@ -53,16 +54,17 @@ class FileStorage(object):
             if not exists(fdstdir):
                 makedirs(fdstdir)
 
-            self._copyfile(fsrc, fdst)
+            self._copyfile(fsrc, fdst, force=relpath in force)
 
 
 class LinkStorage(FileStorage):
     """Storage class that link files."""
 
-    def _copyfile(self, src, dst):
+    def _copyfile(self, src, dst, force=False):
         """Symlink file from source to destination."""
         if exists(dst):
-            if not islink(dst) or realpath(src) == realpath(dst):
+            if (not islink(dst) or realpath(src) == realpath(dst)) \
+                    and not force:
                 return
             remove(dst)
         symlink(src, dst)

--- a/tests/projects/buildtpl/package.json
+++ b/tests/projects/buildtpl/package.json
@@ -8,5 +8,8 @@
   "keywords": [],
   "author": "",
   "license": "ISC",
-  "description": ""
+  "description": "",
+  "devDependencies": {
+    "lodash": "~4"
+  }
 }

--- a/tests/test_pywebpack.py
+++ b/tests/test_pywebpack.py
@@ -149,8 +149,11 @@ def test_bundleproject(builddir, bundledir, destdir):
 
     # Assert generated package.json
     package_json = json_from_file(project.npmpkg.package_json_path)
-    for k in ['dependencies', 'devDependencies', 'peerDependencies']:
-        assert package_json[k] == project.dependencies[k]
+    # Coming from bundle
+    assert package_json['dependencies'] == {'lodash': '~4'}
+    # Coming from source package.json
+    assert package_json['devDependencies'] == {'lodash': '~4'}
+    assert package_json['peerDependencies'] == {}
 
     # Build project and see that it works.
     project.install()

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -20,7 +20,7 @@ from pywebpack.storage import FileStorage, LinkStorage, iter_files
 
 def test_iterfiles(sourcedir):
     """Test file iteration."""
-    assert [x[1] for x in iter_files(sourcedir)] == [
+    assert sorted([x[1] for x in iter_files(sourcedir)]) == [
         'buildtpl/package.json',
         'buildtpl/webpack.config.js',
         'bundle/index.js',


### PR DESCRIPTION
* WebpackBundleProject first copies the package.json and afterwards
  updates it, resulting in a file on disk which is newer than the
  source file. This prevents the package.json from being updated.

* Adds support in storage class for always overwrite certain files
  even if destination files are newer than source files.