### PR TITLE
Don’t generate invalid closing </link> tags

### DIFF
--- a/pywebpack/manifests.py
+++ b/pywebpack/manifests.py
@@ -78,7 +78,7 @@ class ManifestEntry(object):
 
     templates = {
         '.js': '<script src="{}"></script>',
-        '.css': '<link rel="stylesheet" href="{}"></link>',
+        '.css': '<link rel="stylesheet" href="{}" />',
     }
 
     def __init__(self, name, paths):

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -34,8 +34,8 @@ def test_render(exmanif):
         '<script src="/a.js"></script>' \
         '<script src="/b.js"></script>'
     assert exmanif.styles.render() == exmanif['styles'].render() == \
-        '<link rel="stylesheet" href="/a.css"></link>' \
-        '<link rel="stylesheet" href="/b.css"></link>'
+        '<link rel="stylesheet" href="/a.css" />' \
+        '<link rel="stylesheet" href="/b.css" />'
 
 
 def test_manifest_add_same_name():


### PR DESCRIPTION
These are forbidden in HTML 4 and HTML5.

https://www.w3.org/TR/html401/struct/links.html#edef-LINK
https://www.w3.org/TR/html5/document-metadata.html#the-link-element

Use self-closing syntax for XHTML compatibility.