### PR TITLE
Check the exit code from npm processes

### DIFF
--- a/pywebpack/helpers.py
+++ b/pywebpack/helpers.py
@@ -38,6 +38,17 @@ def cached(f):
     return inner
 
 
+def check_exit(f):
+    """Decorator to ensure that an NPM process exited successfully."""
+    @wraps(f)
+    def inner(self, *args, **kwargs):
+        exit_code = f(self, *args, **kwargs)
+        if exit_code != 0:
+            raise RuntimeError("Process exited with code {}".format(exit_code))
+        return exit_code
+    return inner
+
+
 def merge_deps(deps, bundles_deps):
     """Merge NPM dependencies."""
     keys = ['dependencies', 'devDependencies', 'peerDependencies']

--- a/pywebpack/project.py
+++ b/pywebpack/project.py
@@ -18,7 +18,7 @@ from os.path import dirname, exists, join
 
 from pynpm import NPMPackage, YarnPackage
 
-from .helpers import cached, merge_deps
+from .helpers import cached, check_exit, merge_deps
 from .storage import FileStorage
 
 
@@ -46,6 +46,7 @@ class WebpackProject(object):
         """Get API to NPM package."""
         return NPMPackage(self.path)
 
+    @check_exit
     def install(self, *args):
         """Install project."""
         return self.npmpkg.install(*args)
@@ -57,6 +58,7 @@ class WebpackProject(object):
             raise RuntimeError('Invalid NPM script.')
         return self.npmpkg.run_script(script_name, *args)
 
+    @check_exit
     def build(self, *args):
         """Run build script."""
         return self.run('build', *args)

--- a/tests/test_pywebpack.py
+++ b/tests/test_pywebpack.py
@@ -12,6 +12,7 @@
 from __future__ import absolute_import, print_function
 
 import json
+import os
 from os.path import exists, join
 
 import pytest
@@ -83,6 +84,14 @@ def test_project_buildall(simpleprj):
 
 def test_project_no_scripts(brokenprj):
     project = WebpackProject(brokenprj)
+    with pytest.raises(RuntimeError):
+        project.buildall()
+
+
+def test_project_failed_build(simpleprj):
+    # Remove a file necessary for the build
+    os.unlink(os.path.join(os.path.dirname(simpleprj), 'index.js'))
+    project = WebpackProject(simpleprj)
     with pytest.raises(RuntimeError):
         project.buildall()
 


### PR DESCRIPTION
Without this, npm errors pass silently, potentially leading to 'successful' incomplete webpack builds.