### PR TITLE
project: fix for package.json being overwritten

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,12 @@
 Changes
 =======
 
+Version 1.2.0 (released 2021-01-21)
+
+- Fixes an issue where if you were using WebpackBundleProject with
+  the LinkStorage to make symlinks, you would end up having your source
+  package.json overwritten.
+
 Version 1.1.0 (released 2020-05-25)
 
 - Adds support for collecting aliases from bundles.

--- a/pywebpack/storage.py
+++ b/pywebpack/storage.py
@@ -68,10 +68,13 @@ class FileStorage(object):
             remove(dst)
         copy(src, dst)
 
-    def run(self, force=None):
+    def run(self, force=None, skip=None):
         """Copy files from source to destination."""
         force = force or {}
+        skip = skip or []
         for fsrc, relpath in self:
+            if relpath in skip:
+                continue
             fdst = join(self.dstdir, relpath)
             fdstdir = dirname(fdst)
 

--- a/pywebpack/version.py
+++ b/pywebpack/version.py
@@ -15,4 +15,4 @@ and parsed by ``setup.py``.
 
 from __future__ import absolute_import, print_function
 
-__version__ = '1.1.0'
+__version__ = '1.2.0'


### PR DESCRIPTION
* Fixes an issue where if you were using WebpackBundleProject with
  the LinkStorage to make symlinks, you would end up having your source
  package.json overwritten.