### PR TITLE
npm: change deps merging algorithm

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,11 +10,7 @@
 
 """Sphinx configuration."""
 
-from __future__ import print_function
-
 import sys
-
-import sphinx.environment
 
 from pywebpack import __version__
 

--- a/pywebpack/__init__.py
+++ b/pywebpack/__init__.py
@@ -304,8 +304,6 @@ The manifest entries can be retrieved as object attributes or items::
 
 """
 
-from __future__ import absolute_import, print_function
-
 from .bundle import WebpackBundle
 from .helpers import bundles_from_entry_point
 from .manifests import (

--- a/pywebpack/bundle.py
+++ b/pywebpack/bundle.py
@@ -9,8 +9,6 @@
 
 """Webpack bundle API."""
 
-from __future__ import absolute_import, print_function
-
 
 class WebpackBundle(object):
     """Webpack bundle."""

--- a/pywebpack/errors.py
+++ b/pywebpack/errors.py
@@ -1,0 +1,18 @@
+# -*- coding: utf-8 -*-
+#
+# This file is part of PyWebpack
+# Copyright (C) 2023 CERN.
+#
+# PyWebpack is free software; you can redistribute it and/or modify
+# it under the terms of the Revised BSD License; see LICENSE file for
+# more details.
+
+"""Errors."""
+
+
+class PyWebpackException(Exception):
+    """Base exception for PyWebpack errors."""
+
+
+class MergeConflictError(PyWebpackException):
+    """Base exception for PyWebpack errors."""

--- a/pywebpack/helpers.py
+++ b/pywebpack/helpers.py
@@ -12,10 +12,16 @@
 
 from __future__ import absolute_import, print_function
 
+import re
 from functools import wraps
 
 import pkg_resources
-from semver import max_satisfying
+
+# https://semver.org/#is-there-a-suggested-regular-expression-regex-to-check-a-semver-string
+# Differences:
+# - `^\D*`: ignores the first not numberic char (major version), e.g. ~ or <
+# - minor and patch versions are optional
+SEM_VER = r"^\D*(?P<major>0|[1-9]\d*)\.?(?P<minor>0|[1-9]\d*)?\.?(?P<patch>0|[1-9]\d*)?(?:-(?P<prerelease>(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\.(?:0|[1-9]\d*|\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\+(?P<buildmetadata>[0-9a-zA-Z-]+(?:\.[0-9a-zA-Z-]+)*))?$"
 
 
 def _load_ep(ep):
@@ -54,6 +60,58 @@ def check_exit(f):
     return inner
 
 
+def _parse_version(version):
+    """Parse semantic version."""
+    match = re.match(SEM_VER, version)
+    if not match:
+        raise ValueError(f"{version} is not a valid semantic version.")
+    major = match.group("major")
+    minor = match.group("minor") or 0
+    patch = match.group("patch") or 0
+    prerelease = match.group("prerelease") or ""
+    return int(major), int(minor), int(patch), prerelease
+
+
+def max_version(v1, v2):
+    """Given 2 semver strings, return the max version.
+
+    Complies with specification: <https://semver.org/#spec-item-11>.
+    """
+    v1_maj, v1_min, v1_patch, v1_pre = _parse_version(v1)
+    v2_maj, v2_min, v2_patch, v2_pre = _parse_version(v2)
+
+    if v1_maj == v2_maj:
+        if v1_min == v2_min:
+            if v1_patch == v2_patch:
+                if v1_pre and v2_pre:
+                    # check pre-release
+                    v1_pre_tags = v1_pre.split(".")
+                    v2_pre_tags = v2_pre.split(".")
+                    # zip creates pairs for shortest list
+                    for v1_pre_tag, v2_pre_tag in zip(v1_pre_tags, v2_pre_tags):
+                        if v1_pre_tag == v2_pre_tag:
+                            continue
+                        if v1_pre_tag.isdigit() and v2_pre_tag.isdigit():
+                            _max = max(int(v1_pre_tag), int(v2_pre_tag))
+                        else:
+                            _max = max(v1_pre_tag, v2_pre_tag)
+                        return v1 if _max == v1_pre_tag else v2
+                    # lists have different lengths: return the longest
+                    return v1 if len(v1_pre_tags) > len(v2_pre_tags) else v2
+                elif v1_pre and not v2_pre:
+                    return v2
+                elif v2_pre and not v1_pre:
+                    return v1
+                # identical: no pre-release, return any (the first)
+                return v1
+            # return higher patch
+            return v1 if v1_patch > v2_patch else v2
+        # return higher minor
+        return v1 if v1_min > v2_min else v2
+    # return higher major
+    return v1 if v1_maj > v2_maj else v2
+
+
 def merge_deps(deps, bundles_deps):
     """Merge NPM dependencies."""
     keys = ["dependencies", "devDependencies", "peerDependencies"]
@@ -64,8 +122,17 @@ def merge_deps(deps, bundles_deps):
             source_deps = bundles_deps[k]
             for pkg, version in source_deps.items():
                 if pkg in target_deps:
-                    satisfying = max_satisfying([target_deps[pkg], version], "*", True)
-                    target_deps[pkg] = satisfying
+                    target_version = target_deps[pkg]
+
+                    v_maj, _, _, _ = _parse_version(version)
+                    tv_maj, _, _, _ = _parse_version(target_version)
+                    if v_maj != tv_maj:
+                        raise RuntimeError(
+                            f"{pkg}: incompatible major versions {version} and {target_version}."
+                        )
+
+                    _max = max_version(version, target_version)
+                    target_deps[pkg] = _max
                 else:
                     target_deps[pkg] = version
     return deps

--- a/pywebpack/helpers.py
+++ b/pywebpack/helpers.py
@@ -10,8 +10,6 @@
 
 """Webpack bundle API."""
 
-from __future__ import absolute_import, print_function
-
 import re
 from functools import wraps
 

--- a/pywebpack/manifests.py
+++ b/pywebpack/manifests.py
@@ -10,8 +10,6 @@
 
 """Webpack manifests API."""
 
-from __future__ import absolute_import, print_function
-
 import json
 import sys
 from os.path import splitext

--- a/pywebpack/project.py
+++ b/pywebpack/project.py
@@ -10,8 +10,6 @@
 
 """API for creating and building Webpack projects."""
 
-from __future__ import absolute_import, print_function
-
 import json
 import shutil
 from os import makedirs

--- a/pywebpack/project.py
+++ b/pywebpack/project.py
@@ -17,6 +17,8 @@ from os.path import dirname, exists, join
 
 from pynpm import NPMPackage, YarnPackage
 
+from pywebpack.errors import MergeConflictError
+
 from .helpers import cached, check_exit, merge_deps
 from .storage import FileStorage
 
@@ -273,7 +275,12 @@ class WebpackBundleProject(WebpackTemplateProject):
         """Get package.json dependencies."""
         res = {"dependencies": {}, "devDependencies": {}, "peerDependencies": {}}
         for b in self.bundles:
-            merge_deps(res, b.dependencies)
+            try:
+                merge_deps(res, b.dependencies)
+            except MergeConflictError as e:
+                conflicting = b.path
+                new_msg = f"{e.args[0]}. Conflicting dependency found in {conflicting}"
+                raise MergeConflictError(new_msg)
         return res
 
     @property

--- a/pywebpack/storage.py
+++ b/pywebpack/storage.py
@@ -9,8 +9,6 @@
 
 """Storage API."""
 
-from __future__ import absolute_import, print_function
-
 from os import listdir, makedirs, remove, symlink, walk
 from os.path import dirname, exists, getmtime, isfile, islink, join, realpath, relpath
 from shutil import copy

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,13 +29,12 @@ python_requires = >=3.7
 zip_safe = False
 install_requires =
     pynpm>=0.1.0
-    node-semver>=0.1.1
 
 [options.extras_require]
 tests =
-    pytest-black>=0.3.0,<0.3.10
+    pytest-black>=0.3.0
     pytest-cache>=1.0
-    pytest-invenio>=1.4.0
+    pytest-invenio>=2.1.0,<3.0.0
     sphinx>=4.5
 # Kept for backwards compatibility
 docs =

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,8 +9,6 @@
 
 """Pytest configuration."""
 
-from __future__ import absolute_import, print_function
-
 import shutil
 import subprocess
 import tempfile

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -10,8 +10,6 @@
 
 """Module tests."""
 
-from __future__ import absolute_import, print_function
-
 import pytest
 
 from pywebpack import (

--- a/tests/test_pywebpack.py
+++ b/tests/test_pywebpack.py
@@ -10,8 +10,6 @@
 
 """Module tests."""
 
-from __future__ import absolute_import, print_function
-
 import json
 import os
 from os.path import exists, join

--- a/tests/test_pywebpack.py
+++ b/tests/test_pywebpack.py
@@ -22,6 +22,7 @@ from pywebpack import (
     WebpackProject,
     WebpackTemplateProject,
 )
+from pywebpack.errors import MergeConflictError
 from pywebpack.helpers import max_version, merge_deps
 
 
@@ -129,7 +130,7 @@ def test_merge_deps(target, source, expected):
 
 
 def test_merge_deps_incompat_major():
-    with pytest.raises(RuntimeError):
+    with pytest.raises(MergeConflictError):
         merge_deps(
             {"dependencies": {"mypkg": "3.3.1"}},
             {"dependencies": {"mypkg": "4.2.1"}},

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -9,8 +9,6 @@
 
 """Storage class test."""
 
-from __future__ import absolute_import, print_function
-
 import time
 from os import remove, symlink, utime
 from os.path import exists, getmtime, islink, join, realpath


### PR DESCRIPTION
- removes node-semver/semver dependency, given the breaking changes of the latest version.
- implements semver comparison, following specs.
- raises when merging deps with incompatible major versions.
- closes https://github.com/inveniosoftware/pywebpack/issues/38