### PR TITLE
Replace pkg_resources with importlib_metadata

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,6 +1,11 @@
 Changes
 =======
 
+Version 2.0.1 (unreleased)
+
+- Removes implicit dependency on setuptools and use importlib-metadata instead of the
+  deprecated pkg_resources module
+
 Version 2.0.0 (released 2024-03-04)
 
 - Removes dependency on node-semver package

--- a/pywebpack/helpers.py
+++ b/pywebpack/helpers.py
@@ -13,7 +13,7 @@
 import re
 from functools import wraps
 
-import pkg_resources
+from importlib_metadata import entry_points
 
 from pywebpack.errors import MergeConflictError
 
@@ -31,7 +31,7 @@ def _load_ep(ep):
 
 def bundles_from_entry_point(group):
     """Load bundles from entry point group."""
-    return (_load_ep(ep) for ep in pkg_resources.iter_entry_points(group))
+    return (_load_ep(ep) for ep in entry_points(group=group))
 
 
 def cached(f):

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,6 +28,7 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
+    importlib-metadata
     pynpm>=0.1.0
 
 [options.extras_require]


### PR DESCRIPTION
pkg_resources is deprecated in favor of `importlib.metadata`. Since the API of `importlib.metadata` had some changes between Python releases I'm using the PyPI version of it which is guaranteed to work on all supported Python versions.

This isn't code we're using in Indico and there do not seem to be any unit tests for it, so I did not test this. However, comparing it to a similar change I made in [flask-pluginengine](https://github.com/indico/flask-pluginengine/pull/16/commits/30eda1d9a12a0e25a80b999d70403914302cacf6) I think it should be fine.