### PR TITLE
Allow setting of copy instructions per bundle

### DIFF
--- a/pywebpack/bundle.py
+++ b/pywebpack/bundle.py
@@ -33,7 +33,9 @@ class WebpackBundle(object):
         :param devDependencies: npm dev dependencies.
         :param peerDependencies: npm peer dependencies.
         :param aliases: Webpack resolver aliases.
-        :param copy: Instructions to copy assets somewhere else.
+        :param copy: List of copy instructions of the shape
+            ``{"from": "source_path", "to": "dest_path"}`` for copying assets.
+            Paths are relative to the directory of the resulting config.
         """
         self.path = path
         self.entry = entry or {}

--- a/pywebpack/bundle.py
+++ b/pywebpack/bundle.py
@@ -21,6 +21,7 @@ class WebpackBundle(object):
         devDependencies=None,
         peerDependencies=None,
         aliases=None,
+        copy=None,
     ):
         """Initialize webpack bundle.
 
@@ -32,6 +33,7 @@ class WebpackBundle(object):
         :param devDependencies: npm dev dependencies.
         :param peerDependencies: npm peer dependencies.
         :param aliases: Webpack resolver aliases.
+        :param copy: Instructions to copy assets somewhere else.
         """
         self.path = path
         self.entry = entry or {}
@@ -41,3 +43,4 @@ class WebpackBundle(object):
             "peerDependencies": peerDependencies or {},
         }
         self.aliases = aliases or {}
+        self.copy = copy or []

--- a/pywebpack/project.py
+++ b/pywebpack/project.py
@@ -239,10 +239,27 @@ class WebpackBundleProject(WebpackTemplateProject):
         return entries["entries"]
 
     @property
+    def copy(self):
+        """Get instructions for copying assets around."""
+        copy_instructions = []
+        for bundle in self.bundles:
+            for copy in bundle.copy:
+                if set(copy.keys()) != {"from", "to"}:
+                    raise RuntimeError(
+                        f"Invalid copy instruction: {copy}. "
+                        "Requires exactly 'to' and 'from' keys to be present."
+                    )
+
+                # NOTE: the validation check is performed in the JS build step
+                copy_instructions.append(copy)
+
+        return copy_instructions
+
+    @property
     def config(self):
         """Inject webpack entry points from bundles."""
         config = super(WebpackBundleProject, self).config
-        config.update({"entry": self.entry, "aliases": self.aliases})
+        config.update({"entry": self.entry, "aliases": self.aliases, "copy": self.copy})
         return config
 
     @property

--- a/pywebpack/project.py
+++ b/pywebpack/project.py
@@ -201,7 +201,6 @@ class WebpackBundleProject(WebpackTemplateProject):
         return join(self._project_template_dir, self._package_json_source_path)
 
     @property
-    @cached
     def allowed_copy_paths(self):
         """Allowed copy paths as ``pathlib.Path`` objects."""
         _paths = self._allowed_copy_paths
@@ -271,6 +270,7 @@ class WebpackBundleProject(WebpackTemplateProject):
     def copy(self):
         """Get (validated) instructions for copying assets around."""
         config_path = self._get_dir_path(self.config_path)
+        allowed_paths = self.allowed_copy_paths
 
         copy_instructions = []
         for bundle in self.bundles:
@@ -286,19 +286,19 @@ class WebpackBundleProject(WebpackTemplateProject):
                 to_path = self._get_dir_path(config_path.joinpath(copy["to"]))
 
                 # If the set of allowed paths is not empty, perform sanity checks
-                if self.allowed_copy_paths:
+                if allowed_paths:
                     from_path_ok = any(
-                        [from_path.is_relative_to(ap) for ap in self.allowed_copy_paths]
+                        [from_path.is_relative_to(ap) for ap in allowed_paths]
                     )
                     to_path_ok = any(
-                        [to_path.is_relative_to(ap) for ap in self.allowed_copy_paths]
+                        [to_path.is_relative_to(ap) for ap in allowed_paths]
                     )
 
                     if not from_path_ok or not to_path_ok:
                         raise RuntimeError(
                             f"Copy instruction '{copy}' is out of bounds "
                             f"({{'from': '{from_path}', 'to': '{to_path}'}}). "
-                            f"Allowed paths: {self.allowed_copy_paths}"
+                            f"Allowed paths: {allowed_paths}"
                         )
 
                 copy_instructions.append(copy)

--- a/pywebpack/project.py
+++ b/pywebpack/project.py
@@ -204,16 +204,17 @@ class WebpackBundleProject(WebpackTemplateProject):
     @cached
     def allowed_copy_paths(self):
         """Allowed copy paths as ``pathlib.Path`` objects."""
+        _paths = self._allowed_copy_paths
         config_path = pathlib.Path(self.config_path)
-        paths = []
-        for p in self._allowed_copy_paths:
+        allowed_copy_paths = []
+        for p in _paths() if callable(_paths) else _paths:
             allowed_path = pathlib.Path(p)
             if not allowed_path.is_absolute():
                 allowed_path = config_path.joinpath(allowed_path)
 
-            paths.append(allowed_path)
+            allowed_copy_paths.append(allowed_path)
 
-        return paths
+        return allowed_copy_paths
 
     @property
     @cached

--- a/tests/test_pywebpack.py
+++ b/tests/test_pywebpack.py
@@ -226,6 +226,7 @@ def test_bundleproject(builddir, bundledir, destdir):
     """Test bundle project."""
     entry = {"app": "./index.js"}
     aliases = {"@app": "index.js"}
+    copy = [{"from": "./source/", "to": "./target/"}]
     bundle = WebpackBundle(
         bundledir,
         entry=entry,
@@ -233,6 +234,7 @@ def test_bundleproject(builddir, bundledir, destdir):
             "lodash": "~4",
         },
         aliases=aliases,
+        copy=copy,
     )
     project = WebpackBundleProject(
         working_dir=destdir,
@@ -243,7 +245,12 @@ def test_bundleproject(builddir, bundledir, destdir):
 
     assert project.bundles == [bundle]
     assert project.entry == entry
-    assert project.config == {"entry": entry, "test": True, "aliases": aliases}
+    assert project.config == {
+        "entry": entry,
+        "test": True,
+        "aliases": aliases,
+        "copy": copy,
+    }
     assert project.dependencies == {
         "dependencies": {
             "lodash": "~4",


### PR DESCRIPTION
Start implementing the configurable `copy` instructions for webpack projects.

Configuring this theme in `webpack.py`:
```py
theme = WebpackThemeBundle(
    import_name=__name__,
    folder="theme/assets",
    default="semantic-ui",
    themes={
        "semantic-ui": {
            "entry": {
                # ...
            },
            "dependencies": {
                # ...
            },
            "aliases": {
                # ...
            },
            "copy": [
                {"from": "../node_modules/tinymce/skins/content/default/content.css", "to": "js/skins/content/default"},
            ]
        },
    },
)
```

Results in the `copy` instructions to be generated in the `config.json` file:
```js
{
  "aliases": {
    // ...
  },
  "build": {
    // ...
  },
  "copy": [
    {
      "from": "../node_modules/tinymce/skins/content/default/content.css",
      "to": "js/skins/content/default"
    }
  ],
  "entry": {
    // ...
  }
}
```

## Limitations

~~Right now, there is no validation about the to/from locations not going out of bounds, and the values are simple string literals.~~
~~Also, it will of course require another PR for `Invenio-Assets` so that the new config is actually used in `webpack.config.js`.~~

Edit: Sanity checks have been implemented in `webpack.config.js`: https://github.com/inveniosoftware/invenio-assets/pull/173

## Checking in Python?

~~The `flask_webpackext.WebpackBundleProject` automatically sets some paths in the project's configuration [based on the Flask application](https://github.com/inveniosoftware/flask-webpackext/blob/master/flask_webpackext/project.py#L25-L56) which may be useful for out-of-bounds checks.
I'm not entirely sure if that is sound from a hierarchy perspective though – it'd be rough for `pywebpack` to rely on values from `flask-webpackext`.~~

Edit: I just implemented the out-of-bounds checks in JS, see above.

## Checking in JS?

Maybe the validation should happen in `webpack.config.js`?
As long as the check (and possible abort) happens before any files are actually copied, I think it should be fine.
Sure that can be swapped out, but changing the `WebpackBundleProject` in Python is just as easy, it just requires changing the `WEBPACKEXT_PROJECT` config value.

## Ease of use?

Edit: See next comment

~~Another question is how to make the configuration more usable.
As described above, the to/from values are just plain string literals which requires some knowledge about the structure in the `instance_path` to be useful at all.
In the current `webpack.config.js`, the `from` paths are usually based on the current directory, and the `to` paths are usually based on the `config.build.assetsPath`:~~
```
        {
          from: path.resolve(__dirname, '../node_modules/tinymce/skins/content/default/content.css'),
          to: path.resolve(config.build.assetsPath, 'js/skins/content/default'),
        },
```

~~Perhaps it would be nice to enable the use of certain "dynamic" base paths.~~