### PR TITLE
chores: replaced importlib_metadata with importlib

### DIFF
--- a/pywebpack/helpers.py
+++ b/pywebpack/helpers.py
@@ -10,10 +10,10 @@
 
 """Webpack bundle API."""
 
+import importlib.metadata as m
 import re
 from functools import wraps
-
-from importlib_metadata import entry_points
+from sys import version_info
 
 from pywebpack.errors import MergeConflictError
 
@@ -145,3 +145,27 @@ def merge_deps(computed_deps, incoming_deps):
                 else:
                     computed[incoming_pkg] = incoming_version
     return computed_deps
+
+
+def entry_points(group):
+    """Entry points.
+
+    Copied here from invenio-base so that we do not introduce a dependency on invenio-base.
+    """
+    if version_info < (3, 10):
+        eps = m.entry_points()
+        # the only reason to add this check is to simplify the tests! the tests
+        # are implemented against python >=3.10 which uses the group keyword.
+        # since we drop python3.9 soon, this should work!
+        # in the tests there is a line which patches the return value of
+        # importlib.metadata.entry_points with a list. this works for
+        # python>=3.10 but not for 3.9
+        # the return value of .get can contain duplicates. the simplest way to
+        # remove is the set() call, to still return a list, list() is called on
+        # set()
+        if isinstance(eps, dict):
+            eps = list(set(eps.get(group, [])))
+    else:
+        eps = m.entry_points(group=group)
+
+    return eps

--- a/setup.cfg
+++ b/setup.cfg
@@ -28,7 +28,6 @@ packages = find:
 python_requires = >=3.7
 zip_safe = False
 install_requires =
-    importlib-metadata
     pynpm>=0.1.0
 
 [options.extras_require]


### PR DESCRIPTION
### Description

Replaced importlib_metadata with importlib, added code from invenio-base to handle py3.9 compatibility

### Checklist

Ticks in all boxes and 🟢 on all GitHub actions status checks are required to merge:

- [x] I'm aware of the [code of conduct](https://inveniordm.docs.cern.ch/contribute/code-of-conduct/).
- [x] I've created [logical separate commits](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commits) and followed the [commit message format](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#commit-message).
- [ ] I've added relevant test cases.
- [ ] I've added relevant documentation.
- [ ] I've marked [translation strings](https://inveniordm.docs.cern.ch/develop/howtos/i18n/).
- [ ] I've identified the [copyright holder(s)](https://inveniordm.docs.cern.ch/contribute/copyright-policy/) and updated copyright headers for touched files (>15 lines contributions).
- [x] I've NOT included third-party code (copy/pasted source code or new dependencies).
    * If you have added [third-party code (copy/pasted or new dependencies)](https://inveniordm.docs.cern.ch/develop/best-practices/commits/#third-party-codedependencies), please reach out to an [architect on Discord](https://discord.gg/8qatqBC).

**Frontend**

- [ ] I've followed the [CSS/JS](https://inveniordm.docs.cern.ch/develop/best-practices/css-js/) and [React](https://inveniordm.docs.cern.ch/develop/best-practices/react/) guidelines.
- [ ] I've followed the [web accessibility](https://inveniordm.docs.cern.ch/develop/best-practices/accessibility/) guidelines.
- [ ] I've followed the [user interface](https://inveniordm.docs.cern.ch/develop/best-practices/ui/) guidelines.


**Reminder**

By using GitHub, you have already agreed to the [GitHub’s Terms of Service](https://help.github.com/articles/github-terms-of-service/#6-contributions-under-repository-license) including that:

1. You license your contribution under the same terms as the current repository’s license.
2. You agree that you have the right to license your contribution under the current repository’s license.
